### PR TITLE
Improve `assert_allocs()` error message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mockalloc"
 version = "0.1.2"
 authors = ["Diggory Blake <diggsey@googlemail.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["memory", "allocation", "mock", "leak", "test"]

--- a/mockalloc-macros/Cargo.toml
+++ b/mockalloc-macros/Cargo.toml
@@ -12,6 +12,6 @@ description = "Procedural macro attribute for the mockalloc crate."
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.7"
-quote = "1"
-syn = { version = "1.0.3", features = ["full"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ impl LocalState {
 }
 
 thread_local! {
-    static ENABLED: Cell<bool> = Cell::new(false);
+    static ENABLED: Cell<bool> = const { Cell::new(false) };
     static LOCAL_STATE: RefCell<LocalState> = RefCell::new(LocalState::default());
 }
 
@@ -500,6 +500,7 @@ mod tests {
     #[global_allocator]
     static A: Mockalloc<LeakingAllocator> = Mockalloc(LeakingAllocator(System));
 
+    #[allow(clippy::vec_box)]
     fn do_some_allocations() -> Vec<Box<i32>> {
         let mut a = Vec::new();
         let mut b = Vec::new();

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -231,7 +231,7 @@ impl TracingState {
         let mut visit_caller = move |caller| {
             mut_callers
                 .entry(caller)
-                .or_insert_with(|| mem::replace(&mut self_callers[caller], Default::default()));
+                .or_insert_with(|| mem::take(&mut self_callers[caller]));
         };
         for leak in self.allocations.values() {
             visit_caller(leak.caller);
@@ -250,9 +250,9 @@ impl TracingState {
 
         TracingInfo {
             callers,
-            leaks: mem::replace(&mut self.allocations, Default::default()),
-            errors: mem::replace(&mut self.errors, Default::default()),
-            free_callers: mem::replace(&mut self.free_callers, Default::default()),
+            leaks: mem::take(&mut self.allocations),
+            errors: mem::take(&mut self.errors),
+            free_callers: mem::take(&mut self.free_callers),
         }
     }
     fn trace_caller(&mut self) -> usize {


### PR DESCRIPTION
Thank you for the good crate.

`assert_allocs()` (and `#[mockalloc::test]`) find allocation-related bugs but it does not print information on allocation. I think reporting alloc information when a bug is found is more useful.

Before:
<img width="462" alt="スクリーンショット 2024-03-20 20 55 26" src="https://github.com/Diggsey/mockalloc/assets/61523777/2fe9f411-338e-42a6-a511-4aa8bc5e844b">

After:
<img width="468" alt="スクリーンショット 2024-03-20 20 53 28" src="https://github.com/Diggsey/mockalloc/assets/61523777/4f7f1a63-8ef3-40d4-857e-6060763a33ef">